### PR TITLE
Fix: Suppress hydration warning for browser extension attributes

### DIFF
--- a/my-app/app/layout.js
+++ b/my-app/app/layout.js
@@ -23,6 +23,7 @@ export default function RootLayout({ children }) {
     <html lang="zh-CN">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
+        suppressHydrationWarning={true}
       >
         <Header />
         <main className="flex-grow">


### PR DESCRIPTION
## 问题描述

修复了首页出现的 React hydration 不匹配错误。错误是由浏览器扩展在客户端添加的 `data-atm-ext-installed` 属性导致的，该属性在服务器端渲染时不存在，造成了 hydration 不匹配。

## 解决方案

在 `app/layout.js` 的 `<body>` 标签上添加了 `suppressHydrationWarning={true}` 属性。

## 更改内容

- ✅ 在 RootLayout 组件的 body 标签添加 `suppressHydrationWarning={true}`
- ✅ 解决了由浏览器扩展引起的 hydration 警告
- ✅ 这是一个安全的修复，只抑制 body 元素的 hydration 警告

## 测试

- [x] 本地开发服务器运行正常
- [x] 页面渲染正确
- [x] Console 中不再出现 hydration 错误

## 影响范围

这个更改只影响 hydration 警告的显示，不会影响应用的功能或性能。这是处理浏览器扩展导致的 hydration 不匹配的标准做法。

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author